### PR TITLE
unf_ext is not required for JRuby.

### DIFF
--- a/unf.gemspec
+++ b/unf.gemspec
@@ -44,20 +44,20 @@ to Ruby/JRuby.
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<unf_ext>, [">= 0"])
+      s.add_runtime_dependency(%q<unf_ext>, [">= 0"]) unless defined? JRUBY_VERSION
       s.add_development_dependency(%q<shoulda>, [">= 0"])
       s.add_development_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.6.4"])
       s.add_development_dependency(%q<rcov>, [">= 0"])
     else
-      s.add_dependency(%q<unf_ext>, [">= 0"])
+      s.add_dependency(%q<unf_ext>, [">= 0"]) unless defined? JRUBY_VERSION
       s.add_dependency(%q<shoulda>, [">= 0"])
       s.add_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_dependency(%q<jeweler>, ["~> 1.6.4"])
       s.add_dependency(%q<rcov>, [">= 0"])
     end
   else
-    s.add_dependency(%q<unf_ext>, [">= 0"])
+    s.add_dependency(%q<unf_ext>, [">= 0"]) unless defined? JRUBY_VERSION
     s.add_dependency(%q<shoulda>, [">= 0"])
     s.add_dependency(%q<bundler>, ["~> 1.0.0"])
     s.add_dependency(%q<jeweler>, ["~> 1.6.4"])


### PR DESCRIPTION
This should result in a gem that JRuby can install.

```
$  jruby -S gem build unf.gemspec
  Successfully built RubyGem
  Name: unf
  Version: 0.0.4
  File: unf-0.0.4.gem

$  jruby -S gem install unf-0.0.4.gem
Successfully installed unf-0.0.4
1 gem installed
```
