### PR TITLE
Use standard shortcode for BSD-2-Clause

### DIFF
--- a/unf.gemspec
+++ b/unf.gemspec
@@ -13,7 +13,7 @@ to Ruby/JRuby.
   gem.summary       = %q{A wrapper library to bring Unicode Normalization Form support to Ruby/JRuby}
   gem.homepage      = "https://github.com/knu/ruby-unf"
   gem.platform      = defined?(JRUBY_VERSION) ? 'java' : Gem::Platform::RUBY
-  gem.license       = "2-clause BSDL"
+  gem.license       = "BSD-2-Clause"
 
   gem.files         = `git ls-files`.split("\n")
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
Hi!

Just a simple change to make license-finding tools like [license_finder](https://github.com/pivotal/LicenseFinder) happier based off [industry standards](https://spdx.org/licenses/).

Thanks!