### PR TITLE
Remove test files from bundled gem

### DIFF
--- a/unf.gemspec
+++ b/unf.gemspec
@@ -15,9 +15,7 @@ to Ruby/JRuby.
   gem.platform      = defined?(JRUBY_VERSION) ? 'java' : Gem::Platform::RUBY
   gem.license       = "BSD-2-Clause"
 
-  gem.files         = `git ls-files`.split("\n")
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/.*\.rb})
+  gem.files         = `git ls-files -z -- lib`.split("\x0")
   gem.require_paths = ["lib"]
   gem.extra_rdoc_files = ['README.md', 'LICENSE']
 


### PR DESCRIPTION
## Summary

This PR slims down the bundled gem by ~99%.

|                       | Compressed .gem size (bytes) | Unpacked size (bytes) |
|-----------------------|-----------------------------:|----------------------:|
| Before                |                      120,832 |               581,928 |
| After                 |                        6,656 |                 5,418 |
| Difference (absolute) |                      114,176 |               576,510 |
| Difference (relative) |                      -94.49% |               -99.07% |

I believe these savings are worth having because this gem is downloaded millions of times.

## Changes

- Removed the `test_files` declaration from the gemspec (because it is ["no longer useful or recommended to set"](https://github.com/rubygems/guides/issues/90))

- Omitted all files from the gem except for `lib/` and other individually specified files.

<details>
<summary>Before (details)</summary>

```
## Compressed .gem size
120832 bytes

## Gem contents
-rw-r--r-- wheel/wheel     154 2019-10-21 23:40 .gitignore
-rw-r--r-- wheel/wheel     228 2019-10-21 23:40 .travis.yml
-rw-r--r-- wheel/wheel     648 2019-10-21 23:40 CHANGELOG.md
-rw-r--r-- wheel/wheel      88 2019-10-21 23:40 Gemfile
-rw-r--r-- wheel/wheel    1287 2019-10-21 23:40 LICENSE
-rw-r--r-- wheel/wheel     772 2019-10-21 23:40 README.md
-rwxr-xr-x wheel/wheel     482 2019-10-21 23:40 Rakefile
-rwxr-xr-x wheel/wheel     691 2019-10-21 23:40 ext/mkrf_conf.rb
-rw-r--r-- wheel/wheel     698 2019-10-21 23:40 lib/unf.rb
-rw-r--r-- wheel/wheel     800 2019-10-21 23:40 lib/unf/normalizer.rb
-rw-r--r-- wheel/wheel     521 2019-10-21 23:40 lib/unf/normalizer_cruby.rb
-rw-r--r-- wheel/wheel     608 2019-10-21 23:40 lib/unf/normalizer_jruby.rb
-rw-r--r-- wheel/wheel      41 2019-10-21 23:40 lib/unf/version.rb
-rw-r--r-- wheel/wheel     406 2019-10-21 23:40 test/helper.rb
-rw-r--r-- wheel/wheel  571528 2019-10-21 23:40 test/normalization-test.txt
-rw-r--r-- wheel/wheel    1671 2019-10-21 23:40 test/test_unf.rb
-rw-r--r-- wheel/wheel    1305 2019-10-21 23:40 unf.gemspec

## Unpacked size
581928 bytes
```
</details>

<details>
<summary>After (details)</summary>

```
## Compressed .gem size
6656 bytes

## Gem contents
-rw-r--r-- wheel/wheel    1287 2019-10-21 23:40 LICENSE
-rw-r--r-- wheel/wheel     772 2019-10-21 23:40 README.md
-rwxr-xr-x wheel/wheel     691 2019-10-21 23:40 ext/mkrf_conf.rb
-rw-r--r-- wheel/wheel     698 2019-10-21 23:40 lib/unf.rb
-rw-r--r-- wheel/wheel     800 2019-10-21 23:40 lib/unf/normalizer.rb
-rw-r--r-- wheel/wheel     521 2019-10-21 23:40 lib/unf/normalizer_cruby.rb
-rw-r--r-- wheel/wheel     608 2019-10-21 23:40 lib/unf/normalizer_jruby.rb
-rw-r--r-- wheel/wheel      41 2019-10-21 23:40 lib/unf/version.rb

## Unpacked size
5418 bytes
```
</details>
