### PR TITLE
Remove development and test files from the gem package

### DIFF
--- a/unf.gemspec
+++ b/unf.gemspec
@@ -15,9 +15,11 @@ to Ruby/JRuby.
   gem.platform      = defined?(JRUBY_VERSION) ? 'java' : Gem::Platform::RUBY
   gem.license       = "BSD-2-Clause"
 
-  gem.files         = `git ls-files`.split("\n")
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/.*\.rb})
+  gem.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").reject do |file|
+      file.start_with?(*%w[. Gemfile Rakefile test unf.gemspec])
+    end
+  end
   gem.require_paths = ["lib"]
   gem.extra_rdoc_files = ['README.md', 'LICENSE']
 


### PR DESCRIPTION
There are a number of files in the gem package that aren't useful for downstream projects. Removing these reduces the gem package size from **118K** to **7K**!

```diff
< .gitignore
< .travis.yml
  CHANGELOG.md
< Gemfile
  LICENSE
  README.md
< Rakefile
  ext/mkrf_conf.rb
  lib/unf.rb
  lib/unf/normalizer.rb
  lib/unf/normalizer_cruby.rb
  lib/unf/normalizer_jruby.rb
  lib/unf/version.rb
< test/helper.rb
< test/normalization-test.txt
< test/test_unf.rb
< unf.gemspec
```
