### PR TITLE
Remove unused files from package

### DIFF
--- a/unf.gemspec
+++ b/unf.gemspec
@@ -15,9 +15,8 @@ to Ruby/JRuby.
   gem.platform      = defined?(JRUBY_VERSION) ? 'java' : Gem::Platform::RUBY
   gem.license       = "BSD-2-Clause"
 
-  gem.files         = `git ls-files`.split("\n")
+  gem.files         = `git ls-files -z`.split("\x0").reject { |f| f.start_with?(*%w[test/ Rakefile .gitignore .travis.yml]) }
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/.*\.rb})
   gem.require_paths = ["lib"]
   gem.extra_rdoc_files = ['README.md', 'LICENSE']
 


### PR DESCRIPTION
This pull request updates the `*.gemspec` file to optimize the gem package size and structure. The changes include:

- Modified `files` to exclude test files, `Rakefile`, and CI related files from the package.
- Removed the deprecated `test_files` specification as it is no longer recommended.

As a result of this change, the size of the unpacked package file will be reduced from 664KB to 60KB, achieving a reduction of approximately 90%.

Benefits:

- Shorter download times for users
- Reduced container sizes when the gem is included

References:

- https://github.com/rubygems/guides/issues/90
- https://github.com/rubygems/bundler/pull/3207