### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/unf

### DIFF
--- a/unf.gemspec
+++ b/unf.gemspec
@@ -28,4 +28,6 @@ to Ruby/JRuby.
   gem.add_development_dependency 'rdoc', '> 2.4.2'
   gem.add_development_dependency 'test-unit'
   gem.add_development_dependency 'unf_ext', '>= 0' unless defined?(JRUBY_VERSION)
+
+  gem.metadata["changelog_uri"] = gem.homepage + "/blob/master/CHANGELOG.md"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/unf which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/