### PR TITLE
Remove GitHub Actions-related file from artifacts

### DIFF
--- a/unf.gemspec
+++ b/unf.gemspec
@@ -15,7 +15,7 @@ to Ruby/JRuby.
   gem.platform      = defined?(JRUBY_VERSION) ? 'java' : Gem::Platform::RUBY
   gem.license       = "BSD-2-Clause"
 
-  gem.files         = `git ls-files -z`.split("\x0").reject { |f| f.start_with?(*%w[test/ Rakefile .gitignore .travis.yml]) }
+  gem.files         = `git ls-files -z`.split("\x0").reject { |f| f.start_with?(*%w[test/ Rakefile .gitignore .github/]) }
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.require_paths = ["lib"]
   gem.extra_rdoc_files = ['README.md', 'LICENSE']


### PR DESCRIPTION
## Why we need this change

You do not have to include `.github/workflows/test.yml` in the artifact, which has been included in [0.2.0](https://rubygems.org/gems/unf/versions/0.2.0).

## What to change

- Excludes `/.github/**` files from the gem artifacts.

## Refs.

- Follows up #22 and 04d6c8a.